### PR TITLE
Fix: macOS setup instructions and Python 3.12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
+## Quick Setup (macOS/Linux)
+
+### 1. Clone
+```bash
+git clone https://github.com/sachinsenal0x64/fixarr.git
+cd fixarr
+```
+
+### 2. Install Python 3.12 + Tk
+```bash
+brew install python@3.12 python-tk@3.12
+```
+
+### 3. Create Virtual Environment
+```bash
+python3.12 -m venv venv
+source venv/bin/activate
+```
+
+### 4. Install Dependencies
+```bash
+pip install setuptools
+pip install -r requirements.txt
+```
+
+### 5. Run
+```bash
+python fixarr.py
+```
+
+Tested working on macOS Sonoma (Python 3.12, Tkinter)
+No more missing Tkinter or distutils errors.
+
+---
+
 > [!NOTE]  
 > I haven't released the new update yet, but the tool is working fine. If you face any issues, join our Discord using the link below.
 
@@ -5,7 +40,7 @@
   <img align="center" src="https://cdn.jsdelivr.net/gh/sachinsenal0x64/picx-images-hosting@master/logov2.5sr31yyd76w0.png" width="256px" height="256px"/>
 </p>
 
-<h1 align="center"> 🛠️ FIXARR  </h1>
+<h1 align="center"> FIXARR  </h1>
 
 # 🖼️ GUI
 
@@ -109,7 +144,7 @@ or just run .sh File
 
 <br>
 
-🍎 For macOS :
+For macOS :
 
 ```Terminal
 
@@ -117,11 +152,17 @@ For Mac OS With BREW:
 
 if you already not install brew then install its from offical site : https://brew.sh/#install 
 
-brew install python3
-brew install python-tk
-pip3 install customtkinter
-pip3 install -r requirements.txt
-python3 fixarr.py
+# Install Python 3.12 and Tkinter
+brew install python@3.12 python-tk@3.12
+
+# Create virtual environment
+python3.12 -m venv venv
+source venv/bin/activate
+
+# Install setuptools (replaces distutils removed in Python 3.12)
+pip install setuptools
+pip install -r requirements.txt
+python3.12 fixarr.py
 
 
 or just run .sh File

--- a/linux_&_osx_start.sh
+++ b/linux_&_osx_start.sh
@@ -14,12 +14,25 @@ fi
 cd "${CLONE_DIR}"
 echo "Installing Packages......"
 
+# Detect Python version and use python3.12 if available, fallback to python3
+PYTHON_CMD="python3"
+if command -v python3.12 >/dev/null 2>&1; then
+    PYTHON_CMD="python3.12"
+    echo "Using Python 3.12"
+else
+    echo "Python 3.12 not found, using python3"
+fi
+
 # Create virtual environment
-python3 -m venv fixarr
+$PYTHON_CMD -m venv fixarr
 
 # Activate virtual environment
 source fixarr/bin/activate
 
+# Install setuptools first (replaces distutils removed in Python 3.12)
+pip install setuptools
+
+# Install remaining dependencies
 pip install -r requirements.txt
 chmod +x fixarr.py
 python fixarr.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Pillow==10.3.0
 Pygments==2.15.0
 requests==2.31.0
 rich==13.3.3
+setuptools>=68.0.0
 tqdm==4.65.0
 urllib3==1.26.18
 ordered-set==4.1.0


### PR DESCRIPTION
### Summary
Fixes macOS installation and runtime errors caused by Python 3.12 removing `distutils` 
and missing Tkinter linkage.

### Tested On
- macOS Sonoma 14.7  
- Python 3.12.12 (Homebrew)  
- Tkinter verified working  
- All modules install cleanly in venv